### PR TITLE
fix rk3326 gameconole clones boot

### DIFF
--- a/projects/Rockchip/packages/u-boot/patches/RK3326-CLONE/001-set-hwrev.patch
+++ b/projects/Rockchip/packages/u-boot/patches/RK3326-CLONE/001-set-hwrev.patch
@@ -29,7 +29,7 @@ diff -rupN u-boot.orig/cmd/hwrev.c u-boot/cmd/hwrev.c
 +                env_set("dtb_name", "rk3326-k36-clone.dtb");
 +	} else if(check_range(140, 190, hwrev_adc)) {
 +                env_set("hwrev", "r33s");
-+                env_set("dtb_name", "rk3326-gameconsole-r33s");
++                env_set("dtb_name", "rk3326-gameconsole-r33s.dtb");
  	}
  
  	printf("adc0 (hw rev) %d\n", hwrev_adc);


### PR DESCRIPTION
fix typo causing R3XS clones not to boot
