### PR TITLE
Add RG353M/RG353V rumble support

### DIFF
--- a/projects/Rockchip/patches/linux/RK3566-BSP/0006-rg353-add-joypad-rumble.patch
+++ b/projects/Rockchip/patches/linux/RK3566-BSP/0006-rg353-add-joypad-rumble.patch
@@ -1,0 +1,125 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-rg353m-linux.dts b/arch/arm64/boot/dts/rockchip/rk3566-rg353m-linux.dts
+index d98cb34599ed..6e5c3d91203d 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-rg353m-linux.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-rg353m-linux.dts
+@@ -347,6 +347,9 @@ joypad: singleadc-joypad {
+ 
+ 		status = "okay";
+ 
++		/* rumble */
++		pwms = <&pwm5 0 10000 0>;
++
+ 		/* gpio pincontrol setup */
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&btn_pins>;
+diff --git a/arch/arm64/boot/dts/rockchip/rk3566-rg353v-linux.dts b/arch/arm64/boot/dts/rockchip/rk3566-rg353v-linux.dts
+index ecf939b525c8..c2f07a9157cc 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3566-rg353v-linux.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-rg353v-linux.dts
+@@ -347,6 +347,9 @@ joypad: singleadc-joypad {
+ 
+ 		status = "okay";
+ 
++		/* rumble */
++		pwms = <&pwm5 0 10000 0>;
++
+ 		/* gpio pincontrol setup */
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&btn_pins>;
+diff --git a/drivers/input/joystick/singleadcjoy.c b/drivers/input/joystick/singleadcjoy.c
+index 9d4c9bc7f78d..d88226a477bd 100644
+--- a/drivers/input/joystick/singleadcjoy.c
++++ b/drivers/input/joystick/singleadcjoy.c
+@@ -24,6 +24,7 @@
+ #include <linux/property.h>
+ #include <linux/of_gpio.h>
+ #include <linux/delay.h>
++#include <linux/pwm.h>
+ 
+ /*----------------------------------------------------------------------------*/
+ #define DRV_NAME "retrogame_joypad"
+@@ -79,6 +80,9 @@ struct bt_gpio {
+ };
+ 
+ struct joypad {
++	/* PWM device for force-feedback rumble */
++	struct pwm_device *pwm;
++
+ 	struct device *dev;
+ 	int poll_interval;
+ 
+@@ -964,6 +964,63 @@ void rk_send_key_f_key_down(void)
+ }
+ EXPORT_SYMBOL(rk_send_key_f_key_down);
+ 
++static int joypad_play_effect(struct input_dev *dev, void *data,
++			      struct ff_effect *effect)
++{
++	struct joypad *joypad = data;
++	u16 magnitude;
++	int duty, period;
++	struct pwm_args pargs;
++
++	if (effect->type != FF_RUMBLE || !joypad->pwm)
++		return 0;
++
++	magnitude = max(effect->u.rumble.strong_magnitude,
++			effect->u.rumble.weak_magnitude);
++
++	pwm_get_args(joypad->pwm, &pargs);
++	period = pargs.period;
++	if (!period)
++		return 0;
++
++	duty = period - (magnitude * period / 0xffff);
++
++	pwm_config(joypad->pwm, duty, period);
++	pwm_enable(joypad->pwm);
++
++	return 0;
++}
++
++static int joypad_rumble_setup(struct device *dev, struct joypad *joypad,
++			       struct input_dev *input)
++{
++	int error;
++
++	joypad->pwm = devm_pwm_get(dev, NULL);
++	if (IS_ERR(joypad->pwm)) {
++		error = PTR_ERR(joypad->pwm);
++		joypad->pwm = NULL;
++
++		if (error == -EPROBE_DEFER)
++			return error;
++
++		if (error != -ENOENT)
++			dev_warn(dev, "unable to request PWM for rumble: %d\n",
++				 error);
++
++		return 0;
++	}
++
++	input_set_capability(input, EV_FF, FF_RUMBLE);
++
++	error = input_ff_create_memless(input, joypad, joypad_play_effect);
++	if (error) {
++		dev_err(dev, "unable to register rumble, err=%d\n", error);
++		return error;
++	}
++
++	return 0;
++}
+ 
+ static int joypad_input_setup(struct device *dev, struct joypad *joypad)
+ {
+@@ -1015,6 +1072,10 @@ static int joypad_input_setup(struct device *dev, struct joypad *joypad)
+ 			__func__, adc->tuning_p, adc->tuning_n);
+ 	}
+ 
++	error = joypad_rumble_setup(dev, joypad, input);
++	if (error)
++		return error;
++
+ 	/* GPIO key setup */
+ 	__set_bit(EV_KEY, input->evbit);
+ 	for(nbtn = 0; nbtn < joypad->bt_gpio_count; nbtn++) {


### PR DESCRIPTION
## Description

Adds a new RK3566-BSP kernel patch to enable native rumble support for the Anbernic RG353M and RG353V.

This ports the relevant pieces from the ArkOS RG353 kernel implementation:

- adds PWM5 to the RG353M/RG353V `singleadc-joypad` device-tree nodes
- registers standard Linux `FF_RUMBLE` support in `singleadcjoy` when a PWM is available
- keeps rumble optional so devices without a `pwms` property should continue probing normally

Reference implementation:
https://github.com/christianhaitian/RG353VKernel/commit/f82c19740f32bc11a46afdc4edb3148b2fafdfa5

This PR only adds one UnofficialOS build patch file:

`projects/Rockchip/patches/linux/RK3566-BSP/0006-rg353-add-joypad-rumble.patch`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

This has not been hardware tested on an RG353M/RG353V.

Local verification performed:

- [x] Confirmed the PR contains only one new file addition in the UnofficialOS tree
- [x] Checked that the new kernel patch targets the current RK3566-BSP kernel files from `RetroGFX/rk356x-kernel`
- [x] Checked the referenced kernel symbols/configs are present in the RK3566-BSP kernel source/config
- [x] Ran a GitHub Actions kernel-only build test in my fork
- [x] Applied this patch to the RK3566-BSP kernel source used by UnofficialOS
- [x] Configured the kernel with the UnofficialOS RK3566-BSP aarch64 kernel config
- [x] Compiled `drivers/input/joystick/singleadcjoy.o`
- [x] Compiled the RG353M and RG353V device trees

Build log:
https://github.com/r4df0x/UnofficialOS/actions/runs/24285058852/job/70912939712

Not performed:

- [ ] Full UnofficialOS image build
- [ ] RG353M/RG353V hardware test

**Test Configuration**:
* Build OS name and version: GitHub Actions `ubuntu-22.04`
* Docker (Y/N): N for the successful kernel-only test
* UnofficialOS Branch: main
* Any additional information that may be useful: The successful test was a kernel-only compile check, not a full UnofficialOS image build.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
